### PR TITLE
configure project to target java 7

### DIFF
--- a/my-student-financial-account-impl/src/test/java/edu/wisc/student/finance/demo/DemoChargeDaoImplTest.java
+++ b/my-student-financial-account-impl/src/test/java/edu/wisc/student/finance/demo/DemoChargeDaoImplTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Collection;
+import java.util.function.Predicate;
 
 import org.junit.Test;
 
@@ -49,4 +50,22 @@ public class DemoChargeDaoImplTest {
       }
     }
   }
+  
+  
+	/**
+	 * This test verifies that all demo users have a balance due.
+	 * Its not a good test but it serves as proof that we can use java 8.
+	 * @throws IOException
+	 */
+	@Test
+  public void AllDemoUsersHaveBalanceDue() throws IOException {
+	  DemoChargeDaoImpl service = new DemoChargeDaoImpl();
+	   service.init();
+	   boolean allMatch = service.getCharges("bbadger").stream().allMatch( 
+			   (p)-> p.getBalanceDue().compareTo(new BigDecimal(0)) != 0
+			  );
+	   assertTrue(allMatch);
+  }
 }
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,10 @@
 		<uwss.version>0.1.1-SNAPSHOT</uwss.version>
 		<activeProfiles>local-users</activeProfiles>
 		<spring.profiles.active>local-users</spring.profiles.active>
+		<maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
+	    <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
+		<maven.compiler.testSource>1.8</maven.compiler.testSource>
 	</properties>
 
 	<dependencyManagement>
@@ -160,8 +164,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>${maven.compiler.target}</source>
+                    <target>${maven.compiler.source}</target>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -171,6 +175,47 @@
 					<skip>true</skip>
 				</configuration>
 			</plugin>
+		    <plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>1.3.1</version>
+				<executions>
+				 <execution>
+					<id>enforce-java</id>
+					<goals>
+						<goal>enforce</goal>
+					</goals>
+					<configuration>
+						<rules>
+							<requireJavaVersion>
+								<version>${maven.compiler.testTarget}</version>
+							</requireJavaVersion>
+						</rules>
+					</configuration>
+				</execution>
+			</executions>
+		</plugin>
+		<plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>animal-sniffer-maven-plugin</artifactId>
+            <version>1.7</version>
+            <executions>
+               <execution>
+                  <id>signature-check</id>
+                  <phase>verify</phase>
+                  <goals>
+                     <goal>check</goal>
+                  </goals>
+               </execution>
+            </executions>
+            <configuration>
+               <signature>
+                  <groupId>org.codehaus.mojo.signature</groupId>
+                  <artifactId>java17</artifactId>
+                  <version>1.0</version>
+               </signature>
+            </configuration>
+         </plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
But I added some special sauce that allows us to use java 8 in src/test see: [jdk7 and jdk8 in one build](https://gist.github.com/aslakknutsen/9648594)

As a test I modified the ChargeService:
![screen shot 2015-04-02 at 9 45 06 am](https://cloud.githubusercontent.com/assets/3977194/6966234/13c61eda-d91d-11e4-873d-5be35e849dac.png)

And it indeed breaks the build :)
![screen shot 2015-04-02 at 9 45 29 am](https://cloud.githubusercontent.com/assets/3977194/6966238/2054ec76-d91d-11e4-95f7-ce8caf4d70fa.png)

I've also included a silly little test that uses some java8 features.