### PR TITLE
Adding docs and a constructor to GenericDemoDataDao. 

### DIFF
--- a/my-student-financial-account-impl/src/main/java/edu/wisc/student/finance/demo/DemoAuthorizedUsersDaoImpl.java
+++ b/my-student-financial-account-impl/src/main/java/edu/wisc/student/finance/demo/DemoAuthorizedUsersDaoImpl.java
@@ -8,6 +8,9 @@ import java.util.List;
 
 import javax.inject.Named;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import edu.wisc.student.finance.AuthorizedUserDao;
 import edu.wisc.student.finance.v1.AuthorizedUser;
 
@@ -20,14 +23,17 @@ import edu.wisc.student.finance.v1.AuthorizedUser;
 @Named
 public class DemoAuthorizedUsersDaoImpl extends GenericDemoDataDao<AuthorizedUser> implements
     AuthorizedUserDao {
-  
-  public DemoAuthorizedUsersDaoImpl() {
-    super(AuthorizedUser.class);
-  }
-
+  protected final Log log = LogFactory.getLog(this.getClass()); 
   List<AuthorizedUser> demoData = new ArrayList<AuthorizedUser>();
   public static final String DEMO_AUTHZ_USERS_DATA =
       "edu/wisc/student/finance/demo/demo-authorized-users-service-data.json";
+  /**
+   * Constructor passes the same type as T.
+   * @see GenericDemoDataDao#GenericDemoDataDao(Class)
+   */
+  public DemoAuthorizedUsersDaoImpl() {
+    super(AuthorizedUser.class);
+  }
 
   /*
    * (non-Javadoc)
@@ -38,14 +44,14 @@ public class DemoAuthorizedUsersDaoImpl extends GenericDemoDataDao<AuthorizedUse
   public List<AuthorizedUser> getAuthorizedUsers(String pvi) {
     return  getDemoData(pvi);
   }
-
+  /* (non-Javadoc)
+   * @see edu.wisc.student.finance.AuthorizedUserDao#addAuthorizedUser(java.lang.String, edu.wisc.student.finance.v1.AuthorizedUser)
+   */
   @Override
   public void addAuthorizedUser(String pvi, AuthorizedUser authorizedUser) {
-    System.out.println(pvi + " is authorizing " + authorizedUser); // FIXME: delete or turn into
-                                                                   // sanitized log statement
+    log.info(pvi + " is authorizing " + authorizedUser);
     this.data.get(pvi).add(authorizedUser);
   }
-
   /*
    * (non-Javadoc)
    * 

--- a/my-student-financial-account-impl/src/main/java/edu/wisc/student/finance/demo/DemoAuthorizedUsersDaoImpl.java
+++ b/my-student-financial-account-impl/src/main/java/edu/wisc/student/finance/demo/DemoAuthorizedUsersDaoImpl.java
@@ -3,60 +3,56 @@
  */
 package edu.wisc.student.finance.demo;
 
-import java.io.IOException;
-import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import javax.inject.Named;
-
-import org.springframework.core.io.ClassPathResource;
-
-import com.fasterxml.jackson.core.type.TypeReference;
 
 import edu.wisc.student.finance.AuthorizedUserDao;
 import edu.wisc.student.finance.v1.AuthorizedUser;
 
 /**
  * Demo implementation of {@link AuthorizedUserDao}.
+ * 
  * @author Collin Cudd
  *
  */
 @Named
-public class DemoAuthorizedUsersDaoImpl extends GenericDemoDataDao<AuthorizedUser> implements AuthorizedUserDao {
+public class DemoAuthorizedUsersDaoImpl extends GenericDemoDataDao<AuthorizedUser> implements
+    AuthorizedUserDao {
+  
+  public DemoAuthorizedUsersDaoImpl() {
+    super(AuthorizedUser.class);
+  }
 
-	public static final String DEMO_AUTHZ_USERS_DATA = "edu/wisc/student/finance/demo/demo-authorized-users-service-data.json";
+  List<AuthorizedUser> demoData = new ArrayList<AuthorizedUser>();
+  public static final String DEMO_AUTHZ_USERS_DATA =
+      "edu/wisc/student/finance/demo/demo-authorized-users-service-data.json";
 
-	/* (non-Javadoc)
-	 * @see edu.wisc.student.finance.AuthorizedUserDao#getAuthorizedUsers(edu.wisc.uwss.UWUserDetails)
-	 */
-	@Override
-	public List<AuthorizedUser> getAuthorizedUsers(String pvi) {
-		return getDemoData(pvi);
-	}
+  /*
+   * (non-Javadoc)
+   * 
+   * @see edu.wisc.student.finance.AuthorizedUserDao#getAuthorizedUsers(edu.wisc.uwss.UWUserDetails)
+   */
+  @Override
+  public List<AuthorizedUser> getAuthorizedUsers(String pvi) {
+    return  getDemoData(pvi);
+  }
 
-	@Override
-	public void addAuthorizedUser(String pvi, AuthorizedUser authorizedUser) {
-		System.out.println(pvi + " is authorizing " + authorizedUser); //FIXME: delete or turn into sanitized log statement
-		this.data.get(pvi).add(authorizedUser);
-	}
+  @Override
+  public void addAuthorizedUser(String pvi, AuthorizedUser authorizedUser) {
+    System.out.println(pvi + " is authorizing " + authorizedUser); // FIXME: delete or turn into
+                                                                   // sanitized log statement
+    this.data.get(pvi).add(authorizedUser);
+  }
 
-	/* (non-Javadoc)
-	 * @see edu.wisc.student.finance.demo.GenericDemoDataDao#getDemoDataPath()
-	 */
-	@Override
-	public String getDemoDataPath() {
-		return DEMO_AUTHZ_USERS_DATA;
-	}
-
-	/* (non-Javadoc)
-	 * @see edu.wisc.student.finance.demo.GenericDemoDataDao#readDemoData()
-	 */
-	@Override
-	protected Map<String, List<AuthorizedUser>> readDemoData() throws IOException {
-		try (InputStream is = new ClassPathResource(getDemoDataPath()).getInputStream()) {
-			return mapper.readValue(is, new TypeReference<Map<String, List<AuthorizedUser>>>() { });
-		}
-	}
-
+  /*
+   * (non-Javadoc)
+   * 
+   * @see edu.wisc.student.finance.demo.GenericDemoDataDao#getDemoDataPath()
+   */
+  @Override
+  public String getDemoDataPath() {
+    return DEMO_AUTHZ_USERS_DATA;
+  }
 }

--- a/my-student-financial-account-impl/src/main/java/edu/wisc/student/finance/demo/DemoChargeDaoImpl.java
+++ b/my-student-financial-account-impl/src/main/java/edu/wisc/student/finance/demo/DemoChargeDaoImpl.java
@@ -3,30 +3,29 @@
  */
 package edu.wisc.student.finance.demo;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.Collection;
-import java.util.List;
-import java.util.Map;
 
 import javax.inject.Named;
-
-import org.springframework.core.io.ClassPathResource;
-
-import com.fasterxml.jackson.core.type.TypeReference;
 
 import edu.wisc.student.finance.ChargeDao;
 import edu.wisc.student.finance.v1.ChargeType;
 
 /**
- * Demo implementation of {@link ChargeDao}.
+ * Demo implementation of {@link ChargeDao} backed by {@link GenericDemoDataDao}.
  * 
  * @author Nicholas Blair
  */
 @Named
 public class DemoChargeDaoImpl extends GenericDemoDataDao<ChargeType> implements ChargeDao {
 	
-	public static final String DEMO_CHARGE_DATA = "edu/wisc/student/finance/demo/demo-charge-service-data.json";
+	/**
+   * @param typeParameterClass
+   */
+  public DemoChargeDaoImpl() {
+    super(ChargeType.class);
+  }
+
+  public static final String DEMO_CHARGE_DATA = "edu/wisc/student/finance/demo/demo-charge-service-data.json";
   
   /*
    * (non-Javadoc)
@@ -44,14 +43,4 @@ public class DemoChargeDaoImpl extends GenericDemoDataDao<ChargeType> implements
 	public String getDemoDataPath() {
 		return DEMO_CHARGE_DATA;
 	}
-
-	/* (non-Javadoc)
-	 * @see edu.wisc.student.finance.demo.GenericDemoDataDao#readDemoData()
-	 */
-	@Override
-	protected Map<String, List<ChargeType>> readDemoData() throws IOException {
-	   try (InputStream is = new ClassPathResource(getDemoDataPath()).getInputStream()) {
-		       return mapper.readValue(is, new TypeReference<Map<String, List<ChargeType>>>() { });
-		   }
-	   }
 }

--- a/my-student-financial-account-impl/src/main/java/edu/wisc/student/finance/demo/DemoChargeDaoImpl.java
+++ b/my-student-financial-account-impl/src/main/java/edu/wisc/student/finance/demo/DemoChargeDaoImpl.java
@@ -17,16 +17,15 @@ import edu.wisc.student.finance.v1.ChargeType;
  */
 @Named
 public class DemoChargeDaoImpl extends GenericDemoDataDao<ChargeType> implements ChargeDao {
-	
-	/**
-   * @param typeParameterClass
+  public static final String DEMO_CHARGE_DATA = "edu/wisc/student/finance/demo/demo-charge-service-data.json";
+
+  /**
+   * Constructor passes the same type as T.
+   * @see GenericDemoDataDao#GenericDemoDataDao(Class)
    */
   public DemoChargeDaoImpl() {
     super(ChargeType.class);
   }
-
-  public static final String DEMO_CHARGE_DATA = "edu/wisc/student/finance/demo/demo-charge-service-data.json";
-  
   /*
    * (non-Javadoc)
    * @see edu.wisc.student.finance.ChargeDao#getCharges(java.lang.String)
@@ -35,7 +34,6 @@ public class DemoChargeDaoImpl extends GenericDemoDataDao<ChargeType> implements
   public Collection<ChargeType> getCharges(String studentIdentifier) {
     return getDemoData(studentIdentifier);
   }
-
 	/* (non-Javadoc)
 	 * @see edu.wisc.student.finance.demo.GenericDemoDataDao#getDemoDataPath()
 	 */

--- a/my-student-financial-account-impl/src/main/java/edu/wisc/student/finance/demo/GenericDemoDataDao.java
+++ b/my-student-financial-account-impl/src/main/java/edu/wisc/student/finance/demo/GenericDemoDataDao.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -14,55 +15,83 @@ import javax.annotation.PostConstruct;
 
 import org.springframework.core.io.ClassPathResource;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.CollectionType;
+import com.fasterxml.jackson.databind.type.MapType;
 
 /**
+ * Abstract class providing methods for loading, and accessing demo data from a json file.
+ * 
+ * 
+ * Subclasses must provide two vital bits of information:
+ * 1) Subclasses must pass in a type via {@link #GenericDemoDataDao(Class)}. Jackson needs to know which type
+ * to unserialize. The Type paramter of the subclass will not suffice due to type erasure.
+ * 
+ * 2) Subclasses must ensure that {@link #getDemoDataPath()} returns a path to a json formatted file on the
+ * classpath. The file must contain properly formatted json objects. The json objects must be of the
+ * same type you specified as the classes type paramater and the same type passed to the constructor.
+ * 
  * @author Collin Cudd
- *
  */
 public abstract class GenericDemoDataDao<T> {
-	/**
-	 * The {@link ObjectMapper} used to serialize/unserialize the data
-	 */
-	protected ObjectMapper mapper = new ObjectMapper();
-	protected Map<String, List<T>> data = Collections.emptyMap();
+  /**
+   * The {@link ObjectMapper} used to serialize/unserialize the data
+   */
+  protected ObjectMapper mapper = new ObjectMapper();
+  protected Map<String, List<T>> data = Collections.emptyMap();
+  private final Class<T> typeParameterClass;
+  
+  /**
+   * Jackson needs type information in order to deserialize, we can't rely on the paramater T due to type erasure, so subclasses must pass in type information here.
+   * @see http://stackoverflow.com/questions/3437897/how-to-get-class-instance-of-generics-type-t
+   * @param typeParameterClass
+   */
+  public GenericDemoDataDao(Class<T> typeParameterClass) {
+    this.typeParameterClass = typeParameterClass;
+}
 
-	  /**
-	   * Initialization method called {@link PostConstruct}.
-	   *
-	   * @see #readDemoData()
-	   * @throws IOException
-	   */
-	  @PostConstruct
-	  protected void init() throws IOException {
-	    data = readDemoData();
-	  }
+  /**
+   * Initialization method called {@link PostConstruct}.
+   *
+   * @see #readDemoData()
+   * @throws IOException
+   */
+  @PostConstruct
+  protected void init() throws IOException {
+    data = readDemoData();
+  }
 
-	/**
-	 * @param key
-	 * @return a {@link List} of values for the given key.
-	 */
-	protected List<T> getDemoData(String key){
-		  List<T> list = data.get(key);
-		  if(list == null){
-			  return Collections.<T>emptyList();
-		  }else{
-			// clone the list so mutations don't go back to persistence
-			return new ArrayList<T>(list);
-		  }
-	  }
+  /**
+   * @param key
+   * @return a {@link List} of values for the given key.
+   */
+  protected List<T> getDemoData(String key) {
+    List<T> list = data.get(key);
+    if (list == null) {
+      return Collections.<T>emptyList();
+    } else {
+      // clone the list so mutations don't go back to persistence
+      return new ArrayList<T>(list);
+    }
+  }
 
-	  /**
-	   * Reads the demo data and returns it as a {@link Map}.
-	   *
-	   * @return
-	   * @throws IOException
-	   */
-	   protected abstract Map<String, List<T>> readDemoData() throws IOException;
-
-	/**
-	 * @return the path to the file containing the demo data
-	 */
-	public abstract String getDemoDataPath();
+  /**
+   * Reads the demo data and returns it as a {@link Map}.
+   *
+   * @return
+   * @throws IOException
+   */
+  protected Map<String, List<T>> readDemoData() throws IOException {
+    CollectionType collectionType = mapper.getTypeFactory().constructCollectionType(ArrayList.class, typeParameterClass);
+    JavaType stringType = mapper.getTypeFactory().constructType(String.class);
+    MapType mapType = mapper.getTypeFactory().constructMapType(HashMap.class, stringType, collectionType);
+    try (InputStream is = new ClassPathResource(getDemoDataPath()).getInputStream()) {
+      return mapper.readValue(is, mapType);
+    }
+  }
+  /**
+   * @return the path to the file containing the demo data
+   */
+  public abstract String getDemoDataPath();
 }


### PR DESCRIPTION
My goal for GenericDemoDataDao is to make it as simply as possible to drop in demo data (via a json formatted file) and for that data to be easily accessible throughout the application.

So, I did a bit of refactoring, subclasses simply need to provide a file location and type information (what kind of objects are in the file).  You no longer need to override the readDemoData() method because you shouldn't need to know the gory details of jackson de/serialization to use this class.  
