### PR TITLE
[SPFP-81] Add servlet-mapping to match angular route config

### DIFF
--- a/my-student-financial-account-war/src/main/webapp/WEB-INF/web.xml
+++ b/my-student-financial-account-war/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,33 @@
+<!DOCTYPE web-app PUBLIC
+        "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
+        "http://java.sun.com/dtd/web-app_2_3.dtd" >
+
+<web-app
+        xmlns="http://java.sun.com/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+        version="2.5">
+    <display-name>Student Parent Financial Portal</display-name>
+    <welcome-file-list>
+        <welcome-file>index.jsp</welcome-file>
+    </welcome-file-list>
+
+    <servlet>
+        <servlet-name>StaticServlet</servlet-name>
+        <jsp-file>/index.jsp</jsp-file>
+    </servlet>
+
+    <!-- Keep this in sync with $routeProvider configuration in my-app/main.js -->
+    <servlet-mapping>
+        <servlet-name>StaticServlet</servlet-name>
+        <url-pattern>/history/*</url-pattern>
+        <url-pattern>/home/*</url-pattern>
+        <url-pattern>/login/*</url-pattern>
+        <url-pattern>/pay/*</url-pattern>
+        <url-pattern>/settings/*</url-pattern>
+        <url-pattern>/summary/*</url-pattern>
+        <url-pattern>/users/*</url-pattern>
+    </servlet-mapping>
+
+</web-app>
+


### PR DESCRIPTION
This can't be done in our existing Java config (to my knowledge), because the xml config from the angularjs-portal overlay takes precedence.

I tried to get fancy and avoid having to keep web.xml and main.js in sync, but ended up timeboxing the effort (See https://github.com/UW-Madison-DoIT/angularjs-portal/pull/215).